### PR TITLE
fix: update K8s resource names to use fully-qualified names

### DIFF
--- a/internal/k8s/runtime_resources.go
+++ b/internal/k8s/runtime_resources.go
@@ -1,22 +1,22 @@
 package k8s
 
 var K8sGeneral = []string{
-	"Configmaps",
-	"DaemonSets",
-	"Deployments",
-	"Jobs",
-	"Nodes",
-	"Pods",
-	"ServiceAccounts",
-	"Services",
-	"StatefulSets",
+	"configmaps",
+	"daemonsets.apps",
+	"deployments.apps",
+	"jobs.batch",
+	"nodes",
+	"pods",
+	"serviceaccounts",
+	"services",
+	"statefulsets.apps",
 }
 
 var K8sClassicOnPrem = []string{
-	"CronJobs",
-	"PersistentVolumeClaims",
-	"PersistentVolumes",
-	"Storageclass",
+	"cronjobs.batch",
+	"persistentvolumeclaims",
+	"persistentvolumes",
+	"storageclasses.storage.k8s.io",
 }
 
 var K8sGitOps = []string{

--- a/internal/k8s/runtime_resources.go
+++ b/internal/k8s/runtime_resources.go
@@ -20,22 +20,22 @@ var K8sClassicOnPrem = []string{
 }
 
 var K8sGitOps = []string{
-	"Products",
-	"PromotionFlows",
-	"PromotionPolicies",
-	"PromotionTemplates",
-	"RestrictedGitSources",
+	"products.codefresh.io",
+	"promotionflows.codefresh.io",
+	"promotionpolicies.codefresh.io",
+	"promotiontemplates.codefresh.io",
+	"restrictedgitsources.codefresh.io",
 }
 
 var K8sArgo = []string{
-	"AnalysisRuns",
-	"AnalysisTemplates",
-	"Applications",
-	"ApplicationSets",
-	"AppProjects",
-	"EventBus",
-	"EventSources",
-	"Experiments",
-	"Rollouts",
-	"Sensors",
+	"analysisruns.argoproj.io",
+	"analysistemplates.argoproj.io",
+	"applications.argoproj.io",
+	"applicationsets.argoproj.io",
+	"appprojects.argoproj.io",
+	"eventbus.argoproj.io",
+	"eventsources.argoproj.io",
+	"experiments.argoproj.io",
+	"rollouts.argoproj.io",
+	"sensors.argoproj.io",
 }

--- a/internal/utils/fetch_and_save.go
+++ b/internal/utils/fetch_and_save.go
@@ -9,9 +9,21 @@ import (
 	"github.com/codefresh-support/codefresh-support-package/internal/k8s"
 )
 
+func extractKind(crdName string) string {
+	parts := strings.Split(crdName, ".")
+	if len(parts) < 2 {
+		return crdName
+	}
+
+	kind := parts[0]
+	return kind
+}
+
 func FetchAndSaveData(namespace string, k8sResources []string, dirPath, version string) error {
 	for _, k8sType := range k8sResources {
-		err := os.MkdirAll(filepath.Join(dirPath, k8sType), os.ModePerm)
+		kind := extractKind(k8sType)
+		kindDir := filepath.Join(dirPath, kind)
+		err := os.MkdirAll(kindDir, os.ModePerm)
 		if err != nil {
 			return fmt.Errorf("error creating directory: %v", err)
 		}
@@ -29,7 +41,7 @@ func FetchAndSaveData(namespace string, k8sResources []string, dirPath, version 
 			continue
 		}
 
-		err = os.WriteFile(filepath.Join(dirPath, k8sType, fmt.Sprintf("_%sList.txt", k8sType)), []byte(k8sResources.List), os.ModePerm)
+		err = os.WriteFile(filepath.Join(kindDir, fmt.Sprintf("_%sList.txt", kind)), []byte(k8sResources.List), os.ModePerm)
 		if err != nil {
 			return fmt.Errorf("error writing resource list: %v", err)
 		}
@@ -69,7 +81,7 @@ func FetchAndSaveData(namespace string, k8sResources []string, dirPath, version 
 						continue
 					}
 
-					logFileName := filepath.Join(dirPath, k8sType, fmt.Sprintf("%s_%s.log", podName, containerMap["name"].(string)))
+					logFileName := filepath.Join(kindDir, fmt.Sprintf("%s_%s.log", podName, containerMap["name"].(string)))
 					err = os.WriteFile(logFileName, []byte(log), os.ModePerm)
 					if err != nil {
 						return fmt.Errorf("error writing log file: %v", err)
@@ -87,7 +99,7 @@ func FetchAndSaveData(namespace string, k8sResources []string, dirPath, version 
 				continue
 			}
 
-			describeFileName := filepath.Join(dirPath, k8sType, fmt.Sprintf("%s.yaml", resourceName))
+			describeFileName := filepath.Join(kindDir, fmt.Sprintf("%s.yaml", resourceName))
 			err = os.WriteFile(describeFileName, []byte(describeOutput), os.ModePerm)
 			if err != nil {
 				return fmt.Errorf("error writing describe file: %v", err)

--- a/internal/utils/fetch_and_save.go
+++ b/internal/utils/fetch_and_save.go
@@ -9,21 +9,9 @@ import (
 	"github.com/codefresh-support/codefresh-support-package/internal/k8s"
 )
 
-func extractKind(crdName string) string {
-	parts := strings.Split(crdName, ".")
-	if len(parts) < 2 {
-		return crdName
-	}
-
-	kind := parts[0]
-	return kind
-}
-
 func FetchAndSaveData(namespace string, k8sResources []string, dirPath, version string) error {
 	for _, k8sType := range k8sResources {
-		kind := extractKind(k8sType)
-		kindDir := filepath.Join(dirPath, kind)
-		err := os.MkdirAll(kindDir, os.ModePerm)
+		err := os.MkdirAll(filepath.Join(dirPath, k8sType), os.ModePerm)
 		if err != nil {
 			return fmt.Errorf("error creating directory: %v", err)
 		}
@@ -41,7 +29,7 @@ func FetchAndSaveData(namespace string, k8sResources []string, dirPath, version 
 			continue
 		}
 
-		err = os.WriteFile(filepath.Join(kindDir, fmt.Sprintf("_%sList.txt", kind)), []byte(k8sResources.List), os.ModePerm)
+		err = os.WriteFile(filepath.Join(dirPath, k8sType, fmt.Sprintf("_%sList.txt", k8sType)), []byte(k8sResources.List), os.ModePerm)
 		if err != nil {
 			return fmt.Errorf("error writing resource list: %v", err)
 		}
@@ -81,7 +69,7 @@ func FetchAndSaveData(namespace string, k8sResources []string, dirPath, version 
 						continue
 					}
 
-					logFileName := filepath.Join(kindDir, fmt.Sprintf("%s_%s.log", podName, containerMap["name"].(string)))
+					logFileName := filepath.Join(dirPath, k8sType, fmt.Sprintf("%s_%s.log", podName, containerMap["name"].(string)))
 					err = os.WriteFile(logFileName, []byte(log), os.ModePerm)
 					if err != nil {
 						return fmt.Errorf("error writing log file: %v", err)
@@ -99,7 +87,7 @@ func FetchAndSaveData(namespace string, k8sResources []string, dirPath, version 
 				continue
 			}
 
-			describeFileName := filepath.Join(kindDir, fmt.Sprintf("%s.yaml", resourceName))
+			describeFileName := filepath.Join(dirPath, k8sType, fmt.Sprintf("%s.yaml", resourceName))
 			err = os.WriteFile(describeFileName, []byte(describeOutput), os.ModePerm)
 			if err != nil {
 				return fmt.Errorf("error writing describe file: %v", err)


### PR DESCRIPTION
use fully qualified crd names, instead of short names, to work as expected in clusters where unrelated CRDs "catch" identical short names.